### PR TITLE
fix(env.jd): fix bug of native js

### DIFF
--- a/public/env.js
+++ b/public/env.js
@@ -1,1 +1,2 @@
-export const CORP_ID = '{corp_id}'
+const CORP_ID = '{corp_id}'
+sessionStorage.setItem('CORP_ID', CORP_ID)

--- a/public/index.html
+++ b/public/index.html
@@ -10,12 +10,12 @@
 </head>
 
 <body>
+<script src="<%= BASE_URL %>env.js"></script>
   <noscript>
     <strong>We're sorry but dingtalk-vue doesn't work properly without JavaScript enabled. Please enable it to
       continue.</strong>
   </noscript>
   <div id="app"></div>
-  <script type="module" src="<%= BASE_URL %>env.js"></script>
   <!-- built files will be auto injected -->
 </body>
 

--- a/src/utils/dingtalk.js
+++ b/src/utils/dingtalk.js
@@ -4,7 +4,7 @@ import {
 import * as dd from 'dingtalk-jsapi/entry/union' // 按需应用，微应用部分
 import requestAuthCode from 'dingtalk-jsapi/api/runtime/permission/requestAuthCode' // 登陆用临时授权码
 import choose from 'dingtalk-jsapi/api/biz/contact/choose' // PC 通讯录选人
-import { CORP_ID } from '../../public/env'
+
 
 /**
  * 鉴权
@@ -40,7 +40,7 @@ export function contactChoose(url, userids) {
         choose({
           users: userids,
           multiple: true, // 是否多选：true多选 false单选； 默认true
-          corpId: process.env.NODE_ENV === 'production' ? CORP_ID : process.env.VUE_APP_CORPID, // 企业id
+          corpId: process.env.NODE_ENV === 'production' ? sessionStorage.getItem('CORP_ID') : process.env.VUE_APP_CORPID, // 企业id
           max: 10 // 人数限制，当multiple为true才生效，可选范围1-1500
         }).then(res => {
           res = JSON.parse(JSON.stringify(res).replace(/emplId/g, 'userid'))

--- a/src/views/login/index.vue
+++ b/src/views/login/index.vue
@@ -19,7 +19,6 @@
 <script>
 import { getAuthCode } from '@/utils/dingtalk'
 import { Message } from 'element-ui'
-import { CORP_ID } from '../../../public/env'
 export default {
   data: () => ({
     loading: true,
@@ -60,7 +59,7 @@ export default {
         })
     } else {
       // 获取钉钉临时授权码
-      getAuthCode(CORP_ID)
+      getAuthCode(sessionStorage.getItem('CORP_ID'))
         .then(res => {
           this.code.authCode = res.code // 获取authcode
           this.$store


### PR DESCRIPTION
> 在开发环境中，我在public下创建了config.js文件，并且用export default方法进行导出。在页面使用的地方使用import config from XXX进入引入。开发过程中，没有出问题，但是在打包发布以后，发现修改config文件并不生效。

> 经过排查才意识到：不打包编译的js文件不识别es6语法，并且不应该使用import方法进行引入，应该按照原生的js文件进行使用。

https://www.jianshu.com/p/cc6e67ce4c07